### PR TITLE
Add personal email providers with score.

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -77,13 +77,24 @@ func splitWords(str string) []string {
 	return strings.Split(str, " ")
 }
 
-var preferredDomains = map[string]interface{}{"gmail.com": nil}
+var preferredDomains = map[string]float64{
+	"gmail.com":                2,
+	"me.com":                   1,
+	"live.com":                 1,
+	"outlook.com":              1,
+	"mail.ru":                  1,
+	"qq.com":                   1,
+	"hotmail.com":              -1,
+	"users.noreply.github.com": -1,
+}
 
-func isPreferredDomain(email string) bool {
+func getPreferredDomainScore(email string) float64 {
 	domain := getDomainFromEmail(email)
-	_, preferred := preferredDomains[domain]
-
-	return preferred
+	score, preferred := preferredDomains[domain]
+	if !preferred {
+		return 0
+	}
+	return score
 }
 
 func isPrimaryDomain(email string) bool {

--- a/email.go
+++ b/email.go
@@ -22,25 +22,24 @@ func ScoreEmails(emails []string) map[string]float64 {
 	r := make(map[string]float64, 0)
 	for _, email := range emails {
 		email = clean(email)
-		r[email] = scoreEmail(email)
+		r[email] = ScoreEmail(email)
 	}
 
 	return r
 }
 
-func scoreEmail(s string) (score float64) {
-	if !isEmail(s) || !isValidTLD(s) {
+//ScoreEmail returns the score for a given email, higher is better.
+func ScoreEmail(email string) (score float64) {
+	if !isEmail(email) || !isValidTLD(email) {
 		score = -1
 		return
 	}
 
-	if isPrimaryDomain(s) {
+	if isPrimaryDomain(email) {
 		score += 1
 	}
 
-	if isPreferredDomain(s) {
-		score += 1
-	}
+	score += getPreferredDomainScore(email)
 
 	return
 }

--- a/email_test.go
+++ b/email_test.go
@@ -8,7 +8,9 @@ var emailProvider = map[string][]string{
 	"foo@bar.com": []string{"foo@bar.com", "foo"},
 
 	//We prefer some domains againsts others
-	"foo@gmail.com": []string{"foo@bar.com", "foo@gmail.com"},
+	"foo@gmail.com":  []string{"foo@bar.com", "foo@gmail.com"},
+	"foo2@gmail.com": []string{"foo@live.com", "foo2@gmail.com"},
+	"foo@live.com":   []string{"foo@bar.com", "foo@live.com"},
 
 	//Local domains
 	"foo@baz.com": []string{"foo@bar.(none)", "foo@baz.com"},
@@ -23,6 +25,6 @@ var emailProvider = map[string][]string{
 
 func (s *PersonalSuite) TestGetBestEmail(c *C) {
 	for best, names := range emailProvider {
-		c.Assert(best, Equals, GetBestEmail(names))
+		c.Assert(GetBestEmail(names), Equals, best)
 	}
 }


### PR DESCRIPTION
- preferredDomains now have per-domain score (e.g. gmail.com scores 2,
  live.com scores 1). There can be also negative scores.
- ScoreEmail is now publicly exposed.
