### PR TITLE
Improve full name scoring for long and capitalized names.

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -5,17 +5,19 @@ import (
 	"unicode"
 
 	"github.com/asaskevich/govalidator"
+	"regexp"
 )
 
-func isFullname(s string) bool {
+func isFullNameCandidate(s string) bool {
 	return !isEmail(s) && !isEmpty(s)
 }
 
-func isOnlyValidChars(s string) bool {
-	s = strings.Replace(s, " ", "", -1)
-	s = strings.Replace(s, "-", "", -1)
+// Matches valid full names in a lax way
+// (e.g. not considering capitalization).
+var fullNameRegex, _ = regexp.Compile("^\\pL+?(\\s+(\\pL{1,2}\\.|\\pL+(-\\pL+)?))*(\\s[IV]+)?$")
 
-	return govalidator.IsUTFLetter(s)
+func isWellFormedFullName(s string) bool {
+	return fullNameRegex.MatchString(s)
 }
 
 func containsNumbers(s string) bool {
@@ -28,12 +30,8 @@ func containsNumbers(s string) bool {
 	return false
 }
 
-func isSingleWord(s string) bool {
-	return len(strings.Split(s, " ")) == 1
-}
-
-func hasLessWordsThan(s string, n int) bool {
-	return len(strings.Split(s, " ")) < n
+func numberOfWords(s string) int {
+	return len(strings.Split(s, " "))
 }
 
 func isEmail(s string) bool {
@@ -48,17 +46,11 @@ func isEmpty(s string) bool {
 	return len(s) == 0
 }
 
-func isUpCaseInitial(s string) bool {
-	return s == upcaseInitialAllWords(strings.ToLower(s))
-}
+var capitalizedFullNameRegex, _ =
+	regexp.Compile("^\\p{Lu}\\p{Ll}*((\\s+\\p{Ll}{1,3}){0,2}\\s+(\\p{Lu}{1,2}\\.|\\p{Lu}\\p{Ll}*(-\\p{Lu}\\p{Ll}*)?))*(\\s[IV]+)?$")
 
-func upcaseInitialAllWords(s string) string {
-	words := strings.Split(s, " ")
-	for i, w := range words {
-		words[i] = upcaseInitial(w)
-	}
-
-	return strings.Join(words, " ")
+func isCapitalizedFullName(s string) bool {
+	return capitalizedFullNameRegex.MatchString(s)
 }
 
 func upcaseInitial(str string) string {

--- a/fullname.go
+++ b/fullname.go
@@ -29,7 +29,7 @@ func ScoreFullNames(names []string) map[string]float64 {
 }
 
 func scoreFullname(s string) (score float64) {
-	if !isFullname(s) {
+	if !isFullNameCandidate(s) {
 		score = -1
 		return
 	}
@@ -39,23 +39,37 @@ func scoreFullname(s string) (score float64) {
 		return
 	}
 
-	if !isSingleWord(s) && hasLessWordsThan(s, 4) {
-		score += 1
+	// Add up to 1 point for names up to 4 words. This covers most common
+	// naming conventions, with few exception.
+	//
+	// In our use case, we found ~98.8% users use at most 3 names, and
+	// 99.7% use at most 4.
+	//
+	// At 5 or more words, non full name and weird results would start
+	// being the norm rather than the exception.
+	nWords := numberOfWords(s)
+	if nWords > 1 && nWords <= 4 {
+		score += float64(nWords) / 4.
 	}
 
 	if isLowerCase(s) {
 		score -= .1
 	}
 
-	if isOnlyValidChars(s) {
+	if isWellFormedFullName(s) {
 		score += 1
 	}
 
-	if isUpCaseInitial(s) {
+	if isCapitalizedFullName(s) {
 		score += 1
 	}
 
-	score += float64(len(s)) / 100
+	// Prefer longer names if they are under a sane length limit.
+	// ~99.9% names we found were, at most, 35 long.
+	length := len(s)
+	if length <= 35 {
+		score += float64(length) / 35
+	}
 
 	return
 }

--- a/fullname_test.go
+++ b/fullname_test.go
@@ -16,7 +16,7 @@ var fullNameProvider = map[string][]string{
 	"Máximo Cuadros Ortiz": []string{"mcuadros", "Máximo Cuadros", "Máximo Cuadros Ortiz"},
 	"Foo Bar":              []string{"foo", "foo bar", "foo ba", "Foo Bar"},
 	"Foo Bar Qux":          []string{"Foo Bar Qux", "Foo Bar"},
-	"Bar Bar Qux":          []string{"Bar Bar Qux", "Bar Bar Qux Bar"},
+	"Bar Bar Qux Bar":      []string{"Bar Bar Qux", "Bar Bar Qux Bar"},
 	"Qux Bar":              []string{"foo bar Qux", "Qux Bar"},
 	"Qux Bazzz":            []string{"Qux Bazzz", "Qux Bar"},
 	"Bar Baz":              []string{"Bar Baz", "B2ar Baz"},
@@ -25,12 +25,21 @@ var fullNameProvider = map[string][]string{
 	"Bär Foo":              []string{"Bär Foo", "Bar Foo"},
 	"Bár Foo":              []string{"Bár Foo", "B�r Foo"},
 	"Bar Foo":              []string{"Bar Foo", "B�r Foo"},
+	"John J. Aa":           []string{"John Aa", "John J.", "John J. Aa"},
+	"John J Ab":            []string{"John Ab", "John J.", "John J Ab"},
+	"John J. Ac":           []string{"John J. Ac", "John J Ac"},
+	"藤原藤原藤原":         []string{"藤原藤原藤原", "2005"},
 	"Foo Garcia-Castro":    []string{"Foo", "Foo Garcia-Castro"},
+	"Foo de la O":          []string{"Foo del Bar", "Foo de la O", "Foo Bar", "Foo de la O blah"},
+	"Foo Bar Baz":          []string{"Fo Ba Ba", "Foo Bar Baz"},
+	"Foo Bar Bar":          []string{"Foo Bar Bar", "Foo Bar Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar"},
 	"bpauls":               []string{"bpauls", "2012-01-13"},
+	"Peter Bar III":        []string{"Peter", "Peter Bar", "Peter Bar III"},
+	"Peter III":            []string{"Peter", "Peter III", "Peter III Bar"},
 }
 
 func (s *PersonalSuite) TestGetBestFullName(c *C) {
 	for best, names := range fullNameProvider {
-		c.Assert(best, Equals, GetBestFullName(names))
+		c.Assert(GetBestFullName(names), Equals, best)
 	}
 }


### PR DESCRIPTION
- Improve handling of names with initials and dots.
- Improve handling of hyphenated name. Instead if ignoring
  hyphens, we check if they are used in a word, and not at
  the begining or end of a word.
- Recognize names with
- Prefer names with more words in it, up to 4 words.
- Prefer longer names, up to 35 characters.
