### PR TITLE
Skip title prefix when getting first name.

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -18,6 +18,16 @@ func isOnlyValidChars(s string) bool {
 	return govalidator.IsUTFLetter(s)
 }
 
+var titlePrefixes = map[string]interface{}{
+	"Mr":nil, "Ms":nil, "Mrs":nil, "Miss":nil, "Sir":nil, "Lady":nil, "Lord":nil,
+	"Dr":nil, "Prof":nil,
+}
+
+func isTitlePrefix(s string) bool {
+	_, present := titlePrefixes[s]
+	return present
+}
+
 func containsNumbers(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if s[i] >= '0' && s[i] <= '9' {

--- a/firstname.go
+++ b/firstname.go
@@ -11,7 +11,10 @@ func GetBestFirstname(names []string) string {
 		return ""
 	}
 
-	for _, name := range words {
+	for idx, name := range words {
+		if idx == 0 && isTitlePrefix(name) {
+			continue
+		}
 		if len(name) > 1 {
 			return name
 		}

--- a/firstname_test.go
+++ b/firstname_test.go
@@ -10,10 +10,14 @@ var firstNameProvider = map[string][]string{
 	"":       []string{"QUX", "Foo"},
 	"Bar":    []string{"Bar Foo", "B�r Foo"},
 	"Qux":    []string{"A. Qux Foo", "B�r Foo"},
+	"Peter":  []string{"Mr. Peter Foo"},
+	"Helen":  []string{"Mrs. Helen Foo"},
+	"Who":    []string{"Dr. Who Foo"},
+	"Whoa":   []string{"Prof Whoa Foo"},
 }
 
 func (s *PersonalSuite) TestGetBestFirstname(c *C) {
 	for best, names := range firstNameProvider {
-		c.Assert(best, Equals, GetBestFirstname(names))
+		c.Assert(GetBestFirstname(names), Equals, best)
 	}
 }


### PR DESCRIPTION
Mr. Mrs., Dr. and other title prefix will be
ignored on GetBestFirstName.
