### PR TITLE
avoid using negative scores for emails.

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -79,24 +79,24 @@ func splitWords(str string) []string {
 	return strings.Split(str, " ")
 }
 
-var preferredDomains = map[string]float64{
+var preferredDomains = map[string]uint8{
 	"gmail.com":                2,
 	"me.com":                   1,
 	"live.com":                 1,
 	"outlook.com":              1,
 	"mail.ru":                  1,
 	"qq.com":                   1,
-	"hotmail.com":              -1,
-	"users.noreply.github.com": -1,
+	"hotmail.com":              0,
+	"users.noreply.github.com": 0,
 }
 
 func getPreferredDomainScore(email string) float64 {
 	domain := getDomainFromEmail(email)
 	score, preferred := preferredDomains[domain]
 	if !preferred {
-		return 0
+		return 0.5
 	}
-	return score
+	return float64(score)
 }
 
 func isPrimaryDomain(email string) bool {

--- a/email_test.go
+++ b/email_test.go
@@ -5,12 +5,18 @@ import (
 )
 
 var emailProvider = map[string][]string{
+	// Invalid emails are ignored
 	"foo@bar.com": []string{"foo@bar.com", "foo"},
+	"":            []string{"foo"},
 
 	//We prefer some domains againsts others
 	"foo@gmail.com":  []string{"foo@bar.com", "foo@gmail.com"},
 	"foo2@gmail.com": []string{"foo@live.com", "foo2@gmail.com"},
 	"foo@live.com":   []string{"foo@bar.com", "foo@live.com"},
+
+	"foo@hotmail.com":              []string{"foo@hotmail.com"},
+	"foo@users.noreply.github.com": []string{"foo@users.noreply.github.com"},
+	"foo@mydomain.com":             []string{"foo@mydomain.com", "foo@hotmail.com"},
 
 	//Local domains
 	"foo@baz.com": []string{"foo@bar.(none)", "foo@baz.com"},


### PR DESCRIPTION
- When an email gets a negative score, it gets discarded
  by GetBestEmail.
- We only want that for invalid emails.
- So we avoid using negative scores for other cases.
